### PR TITLE
Fix Django 1.7 warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.3'
+version = '0.4'
 
 setup(name='django-site-notifications',
       version=version,

--- a/site_notifications/managers.py
+++ b/site_notifications/managers.py
@@ -10,11 +10,14 @@ class NotificationQuerySet(QuerySet):
         return self.filter(start_date__lte=datetime.now(), end_date__gte=datetime.now())
 
 class NotificationManager(Manager):
-    def get_query_set(self):
+    def get_query_set(self):  # Removed in django1.8
         return NotificationQuerySet(self.model, using=self._db)
 
+    def get_queryset(self):
+        return self.get_queryset()
+
     def active(self):
-        return self.get_query_set().active()
+        return self.get_queryset().active()
 
     def active_notifications(self):
-        return self.get_query_set().active().active_notifications()
+        return self.get_queryset().active().active_notifications()

--- a/site_notifications/models.py
+++ b/site_notifications/models.py
@@ -6,7 +6,7 @@ from site_notifications.choices import STATUS_CHOICES
 class Notification(models.Model):
     start_date = models.DateTimeField(null=True)
     end_date = models.DateTimeField(null=True)
-    enabled = models.BooleanField()
+    enabled = models.BooleanField(default=False)
     message = models.TextField(null=True, blank=False)
 
     status = models.IntegerField(max_length=20, choices=STATUS_CHOICES, default=20)


### PR DESCRIPTION
* (1_6.W002) BooleanField does not have a default value.
*  RemovedInDjango18Warning: `NotificationManager.get_query_set` method should be renamed `get_queryset`.